### PR TITLE
add socks5 proxy support. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Usage
 ```javascript
 var bosonnlp = require('bosonnlp');
 var nlp = new bosonnlp.BosonNLP('YOUR_API_KEY');
+//if you run behind a socks5 proxy. Note that behind a http proxy may cause server response 'invalide header'
+//var nlp = new bosonnlp.BosonNLP('YOUR_API_KEY',{{socksHost:'localhost',socksPort:1080}});
 nlp.ner('成都商报记者 姚永忠', function (result) {
 	console.log(result);
 });

--- a/lib/bosonnlp.js
+++ b/lib/bosonnlp.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var http = require('http');
+var socks5=require('socks5-http-client');
 
 var postOptions = {
 	host: "api.bosonnlp.com",
@@ -12,9 +13,13 @@ var postOptions = {
 	}
 };
 
+var socks5ProxyOptions;
+
 module.exports = BosonNLP;
 
-function BosonNLP (token) {
+function BosonNLP (token, socks5Opts) {
+	socks5ProxyOptions = socks5Opts;
+	socks5Opts && (postOptions = Object.assign(postOptions, socks5Opts));
 	postOptions.headers["X-Token"] = token;
 };
 
@@ -78,7 +83,8 @@ function parseDatas (data) {
 };
 
 function sendPost (options, body, callback) {
-	var postReq = http.request(options, function (res) {
+	var protocol = socks5ProxyOptions ? socks5 : http;
+	var postReq = protocol.request(options, function (res) {
 		var data = [];
 		res.setEncoding('utf8');
 		res.on('data', function (chunk) {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "devDependencies": {
     "nodeunit": "*"
   },
+  "dependencies": {
+    "socks5-http-client": "^1.0.2"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/liwenzhu/bosonnlp.git"


### PR DESCRIPTION
Because bosonnlp api not work behind http proxy or response `invalid headers`